### PR TITLE
Set mysql2 gem version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'http://rubygems.org'
 gem 'rails', '4.0.5'
 gem 'jquery-rails', '3.0.4'
 gem 'rails_autolink'
-gem 'mysql2'
+gem 'mysql2', '0.3.16'
 gem 'devise'
 gem 'twitter_oauth', git: 'git://github.com/moomerman/twitter_oauth.git'
 gem 'therubyracer'
@@ -67,4 +67,3 @@ group :test do
   gem 'ZenTest'
   gem 'database_cleaner', '~> 1.2.0'
 end
-

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -390,7 +390,7 @@ DEPENDENCIES
   jquery-rails (= 3.0.4)
   json_spec
   kgio
-  mysql2
+  mysql2 (= 0.3.16)
   nested_form
   newrelic_rpm
   nokogiri
@@ -417,3 +417,6 @@ DEPENDENCIES
   webrat
   will_paginate (~> 3.0.pre2)
   will_paginate-bootstrap
+
+BUNDLED WITH
+   1.11.2


### PR DESCRIPTION
I've fixed the version of the mysql2 gem to 0.3.16. This version works with MySQL server 5.6 without any issues. With version 0.2.24, the database migrations fail with a `NoMethodError: undefined method`accept' for nil:NilClass` error
